### PR TITLE
Add permissions check to the sumz command

### DIFF
--- a/common/src/main/java/net/picopress/mc/mods/zombietactics2/commands/CommandSumZ.java
+++ b/common/src/main/java/net/picopress/mc/mods/zombietactics2/commands/CommandSumZ.java
@@ -7,21 +7,40 @@ import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.permissions.Permission;
+import net.minecraft.server.permissions.PermissionLevel;
 import net.minecraft.world.entity.monster.zombie.Zombie;
 
 
 public class CommandSumZ {
+    public static final Identifier SUMZ_COMMAND_IDENTIFIER = Identifier.fromNamespaceAndPath("zombietactics2", "sumz");
+    public static final Permission SUMZ_PERMISSION = Permission.Atom.create(SUMZ_COMMAND_IDENTIFIER);
+    private static final Permission OP_PERMISSION = new Permission.HasCommandLevel(PermissionLevel.GAMEMASTERS);
+
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(Commands.literal("sumz")
+                .requires(CommandSourceStack::isPlayer) // doesn't always work
+                .requires(source ->
+                        source.permissions().hasPermission(SUMZ_PERMISSION)
+                            || source.permissions().hasPermission(OP_PERMISSION))
                 .then(Commands.argument("spawnCount", IntegerArgumentType.integer(1, 1024))
                         .executes(CommandSumZ::command)));
     }
     // ex) /sumz 32 ==> summon 32 zombies
     public static int command(CommandContext<CommandSourceStack> ctx) {
         CommandSourceStack src = ctx.getSource();
-        ServerLevel world = src.getLevel();
         Component chat;
+
+        // Checking for player, because you can execute this command from console
+        if(!src.isPlayer()) {
+            chat = Component.literal("Cannot execute this command unless you are in player mode");
+            src.sendSystemMessage(chat);
+            return 0;
+        }
+
+        ServerLevel world = src.getLevel();
         int count = ctx.getArgument("spawnCount", Integer.class);
 
         for(int i = 0; i < count; ++ i) {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
   "depends": {
     "fabricloader": ">=0.16.10",
     "minecraft": ">=1.21.11",
-    "java": "21",
+    "java": ">=21",
     "architectury": ">=19",
     "midnightlib": ">=1.9.0",
     "modmenu": ">=17.0.0-beta.1",


### PR DESCRIPTION
Added these checks because the console and all players on the server can summon zombies with /sumz. 
Added a custom permission "zombietactics2.sumz"(or "zombietactics2:sumz") for permission managers like LuckPerms.

Now only players with the permission "zombietactics2.sumz" or OPs can summon zombies. It doesn't affect single player worlds with commands or "cheats" enabled.

Also fixed fabric.mod.json to support newer Java versions.

**I tested everything myself.**